### PR TITLE
feat: Added tarteaucitron configuration

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -10,12 +10,18 @@ import { throttle } from 'throttle-debounce'
 import MutationType from '../constants/mutation-type'
 import EventType from '../constants/event-type'
 import eventBus from '~/utils/event-bus'
+import { trackPageView } from '~/tracking/tracker'
 
 export default Vue.extend({
     data() {
         return {
             resizeCallback: throttle(200, (this as any).onResize),
         }
+    },
+    watch: {
+        $route() {
+            trackPageView(undefined, this.$route.fullPath)
+        },
     },
     beforeMount() {
         this.setWindowSize()

--- a/src/tracking/google-analytics-4.ts
+++ b/src/tracking/google-analytics-4.ts
@@ -1,4 +1,5 @@
 /**
+ * @deprecated Use tarteaucitron for better GDPR integration
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs
  * @param id
  */

--- a/src/tracking/matomo.ts
+++ b/src/tracking/matomo.ts
@@ -1,4 +1,5 @@
 /**
+ * @deprecated Use tarteaucitron for better GDPR integration
  * @see https://developer.matomo.org/guides/tracking-javascript-guide
  * @param {string} id
  * @param {string} matomoUrl

--- a/src/tracking/orejime.ts
+++ b/src/tracking/orejime.ts
@@ -23,6 +23,11 @@ function createTrans(translations: Translations): Function {
     }
 }
 
+/**
+ * @deprecated Use tarteaucitron for better GDPR integration
+ * @param locale
+ * @param privacyPolicyUrl
+ */
 export function createOrejimeConfig(locale: string, privacyPolicyUrl: string): string {
     const translations = getTranslations(locale)
     const trans = createTrans(translations)

--- a/src/tracking/tarteaucitron.ts
+++ b/src/tracking/tarteaucitron.ts
@@ -9,7 +9,7 @@ export interface TarteaucitronConfigOptions {
  * This method initialize TAC directly on your website. If you need to use
  * Google Tag Manager, you should move this configuration to an external GTM tag.
  *
- * Override this method if you need to adjust configuration: such multi-domains cookie
+ * Override this method if you need to adjust configuration: such as multi-domains cookie
  * or exotic trackers, etc
  */
 export function createTarteaucitronConfig(options: TarteaucitronConfigOptions): string {

--- a/src/tracking/tarteaucitron.ts
+++ b/src/tracking/tarteaucitron.ts
@@ -1,0 +1,78 @@
+export interface TarteaucitronConfigOptions {
+    policyUrl?: string
+    googleAnalytics?: string
+    matomoSiteId?: string
+    matomoUrl?: string
+}
+
+/*
+ * This method initialize TAC directly on your website. If you need to use
+ * Google Tag Manager, you should move this configuration to an external GTM tag.
+ *
+ * Override this method if you need to adjust configuration: such multi-domains cookie
+ * or exotic trackers, etc
+ */
+export function createTarteaucitronConfig(options: TarteaucitronConfigOptions): string {
+    let script = `
+        tarteaucitron.init({
+    	  "privacyUrl": "${options.policyUrl}",
+          "bodyPosition": "bottom",
+    	  "hashtag": "#cookie_consent",
+    	  "cookieName": "cookie_consent",
+    	  "orientation": "bottom",
+          "groupServices": false,
+          "serviceDefaultState": "wait",
+    	  "showAlertSmall": false,
+    	  "cookieslist": false,
+          "closePopup": false,
+          "showIcon": false,
+          "iconPosition": "BottomRight",
+    	  "adblocker": false,
+          "DenyAllCta" : true,
+          "AcceptAllCta" : true,
+          "highPrivacy": true,
+    	  "handleBrowserDNTRequest": false,
+    	  "removeCredit": true,
+    	  "moreInfoLink": false,
+          "useExternalCss": true, /* Use _tarteaucitron.scss */
+          "useExternalJs": false,
+          "readmoreLink": "",
+          "mandatory": true,
+          "mandatoryCta": true
+        });
+    `
+
+    /*
+     * Google Analytics (universal)
+     */
+    if (options.googleAnalytics && options.googleAnalytics.startsWith('UA-')) {
+        script += `
+
+        tarteaucitron.user.analyticsUa = '${options.googleAnalytics}';
+        tarteaucitron.user.analyticsAnonymizeIp = true;
+        (tarteaucitron.job = tarteaucitron.job || []).push('analytics');
+        `
+    }
+
+    /*
+     * Google Analytics (GA4)
+     */
+    if (options.googleAnalytics && options.googleAnalytics.startsWith('G-')) {
+        script += `
+
+        tarteaucitron.user.gtagUa = '${options.googleAnalytics}';
+        (tarteaucitron.job = tarteaucitron.job || []).push('gtag');
+        `
+    }
+
+    if (options.matomoSiteId && options.matomoUrl) {
+        script += `
+
+        tarteaucitron.user.matomoId = '${options.matomoSiteId}';
+        tarteaucitron.user.matomoHost = '${options.matomoUrl}';
+        (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
+        `
+    }
+
+    return script
+}


### PR DESCRIPTION
- tarteaucitron configuration
- tarteaucitron base style
- GA4, Universal Analytics, Matomo integration examples
- Added `trackPageView` on $router watch
- Google Tag Manager is loaded aside from tarteaucitron (GTM should load it async, if applicable)