### PR TITLE
refactor: Removed useless I18N_* dotEnv variables

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,11 +11,6 @@ BASE_URL=
 DOCUMENT_PATH=/files
 INTERVENTION_REQUEST_BASE_PATH=assets
 
-I18N_DEFAULT_LOCALE=fr
-I18N_FALLBACK_LOCALE=fr
-# defines an application-wide timezone
-I18N_TIMEZONE=Europe/Paris
-
 # These values must be copied on preprod/prod server .env
 TRAEFIK_HOSTNAME=
 TRAEFIK_NAMESPACE=

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,11 +5,6 @@ stages:
     - docker
     - release
 
-variables:
-    I18N_DEFAULT_LOCALE: fr
-    I18N_FALLBACK_LOCALE: fr
-    I18N_TIMEZONE: Europe/Paris
-
 .cache: &cache
     cache:
         key:

--- a/README.md
+++ b/README.md
@@ -172,19 +172,47 @@ publicRuntimeConfig: {
 
 ## Define an application-wide timezone
 
-Make sure you define a timezone and use `$i18n` preset when formatting dates and time:
+Make sure you define a timezone and use `$i18n` preset when formatting dates and time with `$d` method:
 
-```dotenv
-I18N_TIMEZONE=Europe/Paris
+```js
+// nuxt.config.js
+//
+// Define global app timezone here because i18n config is not editable at runtime
+const defaultTimeZone = 'Europe/Paris'
+const defaultLocale = 'fr'
+const fallbackLocale = 'fr'
 ```
 
-Update environment variables in following files:
+If you are using an `$i18n` preset without timezone, time will be formatted using **user-browser timezone**.
+You can test it in _Chrome Dev Tool > ... > Sensors > Location_.  
 
-- `.env`
-- `.gitlab-ci.yml` if you are using Gitlab CI to build your project
+If you do not want to use `$d` method or a *vueI18n* preset, `$config.defaultTimeZone` 
+will hold your current timezone configuration, then you can use Vanilla JS API to format your date:
 
-If not, time will be formatted using user-browser timezone. You can test it in _Chrome Dev Tool > ... > Sensors > Location_.
-If you do not want to use `$i18n`, `$config.defaultTimeZone` will hold your current timezone configuration.
+```js
+(new Intl.DateTimeFormat(
+  this.$i18n.locale, 
+  {
+    timestyle: 'long', 
+    timeZone: this.$config.defaultTimeZone
+  }
+)).format(new Date())
+```
+
+Or *vueI18n*:
+
+```js
+this.$i18n.d(
+  new Date(), 
+  {
+    timestyle: 'long', 
+    timeZone: this.$config.defaultTimeZone
+  }
+)
+```
 
 Sometimes, using user browser timezone may be a wanted behaviour: to display an interactive date-time specific to user, or
 displaying live or/and online events date-time that will occur world-wide (i.e. a Youtube live event). 
+
+Never alter `Date` objects themselves, always `format` them using the wanted timezone. Or this could lead to unwanted
+behaviours especially if you are using `Date` objects to filter time-based API items.

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -6,12 +6,16 @@ import toBoolean from './src/utils/to-boolean'
 import createSitemaps from './src/utils/roadiz/create-sitemaps'
 
 const locales = ['fr']
+// Define global app timezone here because i18n config is not editable at runtime
+const defaultTimeZone = 'Europe/Paris'
+const defaultLocale = 'fr'
+const fallbackLocale = 'fr'
 
 export default {
     // Global page headers: https://go.nuxtjs.dev/config-head
     head: {
         htmlAttrs: {
-            lang: process.env.I18N_DEFAULT_LOCALE,
+            lang: defaultLocale,
         },
         meta: [
             { charset: 'utf-8' },
@@ -126,7 +130,9 @@ export default {
         apiEndpointPrefix: process.env.API_ENDPOINT_PREFIX,
         baseURL: process.env.BASE_URL,
         documentPath: process.env.DOCUMENT_PATH,
-        defaultTimeZone: process.env.I18N_TIMEZONE,
+        defaultTimeZone,
+        defaultLocale,
+        fallbackLocale,
     },
 
     // https://i18n.nuxtjs.org/
@@ -134,10 +140,10 @@ export default {
         locales,
         detectBrowserLanguage: false,
         strategy: 'prefix',
-        defaultLocale: process.env.I18N_DEFAULT_LOCALE || 'fr',
+        defaultLocale,
         vuex: false,
         vueI18n: {
-            fallbackLocale: process.env.I18N_FALLBACK_LOCALE || 'fr',
+            fallbackLocale,
             messages: locales.reduce((acc, cur) => {
                 // xilofone format: if there is only one language then the file name doesn't include the locale
                 const path = `./src/assets/locales/nuxt${locales.length > 1 ? '.' + cur : ''}.json`
@@ -157,13 +163,13 @@ export default {
                             year: 'numeric',
                             month: 'short',
                             day: 'numeric',
-                            timeZone: process.env.I18N_TIMEZONE,
+                            timeZone: defaultTimeZone,
                         },
                         hour: {
                             hour: '2-digit',
                             minute: '2-digit',
                             hour12: false,
-                            timeZone: process.env.I18N_TIMEZONE,
+                            timeZone: defaultTimeZone,
                         },
                     },
                 }),


### PR DESCRIPTION
Removed useless I18N_* dotEnv variables because vueI18n config is not editable at runtime.

All configuration should be done in `nuxt.config.js` to avoid undefined variables in CI/CD context, or in production environments.