### PR TITLE
feat(form): use status role for error / success messages

### DIFF
--- a/components/organisms/VForm/VForm.vue
+++ b/components/organisms/VForm/VForm.vue
@@ -237,12 +237,14 @@ const formattedSchema = computed(() => {
             <div>
                 <p
                     v-if="errorMessage"
+                    role="status"
                     :class="$style.errors"
                 >
                     {{ $t(errorMessage) }}
                 </p>
                 <p
                     v-if="isSuccess"
+                    role="status"
                     :class="$style.success"
                 >
                     {{ successLabel || $t('form.success') }}


### PR DESCRIPTION
Improve the a11y with `role="status"` https://www.digitala11y.com/status-role/#:~:text=The%20status%20role%20is%20used,be%20announced%20to%20the%20user.