### PR TITLE
test: add compose file for debugging prod build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ logs
 .DS_Store
 .fleet
 .idea
+siege.txt
 
 # Local env files
 .env

--- a/compose.debug-prod.yml
+++ b/compose.debug-prod.yml
@@ -1,0 +1,17 @@
+# docker compose -f compose.prod.yml up --force-recreate
+services:
+    node:
+        build:
+            context: .
+            target: node-prod
+        mem_limit: 512m
+        ports:
+            -   3000:3000
+        tmpfs:
+            - /tmp
+        environment:
+            NUXT_PUBLIC_API_URL: http://localhost:8088
+            NUXT_PUBLIC_API_ENDPOINT_PREFIX: /api
+            NUXT_PUBLIC_INTERVENTION_REQUEST_BASE_URL: http://localhost:8088/assets
+            NUXT_PUBLIC_INTERVENTION_REQUEST_NO_PROCESS_BASE_URL: http://localhost:8088/assets/n
+            NUXT_PUBLIC_INTERVENTION_REQUEST_IMAGES_PATH: /files


### PR DESCRIPTION
- Add a default `compose.debug-prod.yml` file for debugging the production build with Docker
- ignore siege file