### PR TITLE
feat: improve page data

### DIFF
--- a/components/organisms/VDefaultPage/VDefaultPage.vue
+++ b/components/organisms/VDefaultPage/VDefaultPage.vue
@@ -1,15 +1,21 @@
 <script lang="ts" setup>
-import type { RoadizNodesSources, RoadizWalker } from '@roadiz/types'
+import type { PageEntityProps } from '~/types/app'
+import type { NSPage } from '~/types/roadiz'
+import { getBlockCollection } from '~/utils/roadiz/block'
 
-defineProps<{
-    blocks: RoadizWalker[]
-    entity: RoadizNodesSources
-}>()
+const { webResponse } = defineProps<PageEntityProps>()
+
+const page = computed(() => webResponse?.item as NSPage)
+const blocks = computed(() => (webResponse?.blocks && getBlockCollection(webResponse.blocks)) || [])
 </script>
 
 <template>
     <div>
-        {{ entity.title || 'VDefaultPage' }}
+        <h1>{{ page?.title || 'VDefaultPage' }}</h1>
+        <VRoadizBlockFactory
+            v-if="blocks.length"
+            :blocks="blocks"
+        />
     </div>
 </template>
 

--- a/composables/use-alternate-links.ts
+++ b/composables/use-alternate-links.ts
@@ -15,8 +15,8 @@ export function useAlternateLinks(links?: RoadizAlternateLink[]) {
                 : ($i18n.locales.value as LocaleObject[]).map(locale => locale.code)) || []
 
         return alternateLinks.value.sort((a: RoadizAlternateLink, b: RoadizAlternateLink) => {
-            const indexA = locales.includes(a.locale) ? locales.indexOf(a.locale) : 9999
-            const indexB = locales.includes(b.locale) ? locales.indexOf(b.locale) : 9999
+            const indexA = locales.includes(a.locale!) ? locales.indexOf(a.locale!) : 9999
+            const indexB = locales.includes(b.locale!) ? locales.indexOf(b.locale!) : 9999
 
             return indexA - indexB
         })

--- a/composables/use-common-cache-control.ts
+++ b/composables/use-common-cache-control.ts
@@ -1,0 +1,48 @@
+// dunno why but I can't extends the CacheControlOptions type from the nuxt-cache-control module
+
+interface UseCacheControlOptions {
+    maxAge?: number
+    sMaxAge?: number
+    staleWhileRevalidate?: number
+    public?: boolean
+}
+
+interface UseCommonCacheControlsOptions extends UseCacheControlOptions {
+    rawHeader?: string
+}
+
+function isValidAge(age: unknown) {
+    return (typeof age === 'number' && age < 0) || typeof age !== 'number'
+}
+
+function getAgeValue(
+    options: UseCommonCacheControlsOptions | undefined,
+    rawKey: string,
+    key: string,
+) {
+    const regexp = new RegExp(`${rawKey}=(\\d+)`)
+    const rawValue = options?.rawHeader?.match(regexp)?.[1]
+
+    if (rawValue) return Number(rawValue)
+
+    const value = options?.[key as keyof UseCommonCacheControlsOptions]
+
+    if (isValidAge(value)) return value as number
+
+    const cacheControlConfig = useRuntimeConfig().public.cacheControl
+    const configValue = cacheControlConfig?.[key as keyof typeof cacheControlConfig]
+
+    if (isValidAge(configValue)) return configValue as number
+}
+
+export function useCommonCacheControl(options?: UseCommonCacheControlsOptions) {
+    const cacheControlConfig = useRuntimeConfig().public.cacheControl
+    const { isActive: previewIsActive } = useRoadizPreview()
+
+    useCacheControl({
+        maxAge: getAgeValue(options, 'max-age', 'maxAge'),
+        sMaxAge: getAgeValue(options, 's-maxage', 'sMaxAge'),
+        staleWhileRevalidate: getAgeValue(options, 'stale-while-revalidate', 'staleWhileRevalidate'),
+        public: previewIsActive.value ? false : cacheControlConfig?.public ?? true,
+    })
+}

--- a/composables/use-common-cache-control.ts
+++ b/composables/use-common-cache-control.ts
@@ -1,5 +1,4 @@
-// dunno why but I can't extends the CacheControlOptions type from the nuxt-cache-control module
-
+// TODO: extends from useCacheControl() options types
 interface UseCacheControlOptions {
     maxAge?: number
     sMaxAge?: number
@@ -12,7 +11,7 @@ interface UseCommonCacheControlsOptions extends UseCacheControlOptions {
 }
 
 function isValidAge(age: unknown) {
-    return (typeof age === 'number' && age < 0) || typeof age !== 'number'
+    return typeof age === 'number' && age >= 0
 }
 
 function getAgeValue(

--- a/composables/use-current-page.ts
+++ b/composables/use-current-page.ts
@@ -1,9 +1,5 @@
 import type { Page } from '~/composables/use-page'
 
-export function useCurrentPage(page?: Page) {
-    const currentPage = useState<Page>('currentPage', () => ({}))
-
-    if (page) currentPage.value = page
-
-    return currentPage
+export function useCurrentPage() {
+    return useState<Page>('currentPage', () => shallowRef({}))
 }

--- a/composables/use-next-page.ts
+++ b/composables/use-next-page.ts
@@ -1,5 +1,5 @@
 import type { Page } from '~/composables/use-page'
 
 export function useNextPage() {
-    return useState<Page>('nextPage', () => ({}))
+    return useState<Page>('nextPage', () => shallowRef({}))
 }

--- a/composables/use-roadiz-detect-browser-language.ts
+++ b/composables/use-roadiz-detect-browser-language.ts
@@ -1,12 +1,15 @@
 import type { RoadizAlternateLink } from '@roadiz/types'
 import { nuxtI18nOptions } from '#build/i18n.options.mjs'
 
-export async function useRoadizDetectBrowserLanguage({ locale, alternateLinks }: { locale: string, alternateLinks: RoadizAlternateLink[] }) {
+export async function useRoadizDetectBrowserLanguage({ locale, alternateLinks }: {
+    locale: string
+    alternateLinks?: RoadizAlternateLink[]
+}) {
     const { detectBrowserLanguage } = nuxtI18nOptions
 
     if (!detectBrowserLanguage) return
 
-    const isRootPath = useRoute().path === '/' || alternateLinks.some(link => link.url === '/')
+    const isRootPath = useRoute().path === '/' || alternateLinks?.some(link => link.url === '/')
 
     if (!isRootPath && detectBrowserLanguage.redirectOn === 'root') return
 
@@ -18,8 +21,12 @@ export async function useRoadizDetectBrowserLanguage({ locale, alternateLinks }:
     const browserLocale = useBrowserLocale()
     const preferredLocale = detectBrowserLanguage.useCookie ? (cookieLocale || browserLocale) : browserLocale
 
-    if (preferredLocale && preferredLocale !== locale && $i18n.locales.value.find(availableLocale => availableLocale.code === preferredLocale)) {
-        const alternateLink = alternateLinks.find(link => link.locale === preferredLocale)
+    if (
+        preferredLocale
+        && preferredLocale !== locale
+        && $i18n.locales.value.find(availableLocale => availableLocale.code === preferredLocale)
+    ) {
+        const alternateLink = alternateLinks?.find(link => link.locale === preferredLocale)
 
         if (alternateLink) await navigateTo(alternateLink.url, { replace: true, external: true })
     }

--- a/composables/use-roadiz-head.ts
+++ b/composables/use-roadiz-head.ts
@@ -1,14 +1,14 @@
 import { joinURL } from 'ufo'
 import type { RoadizAlternateLink, RoadizWebResponse } from '@roadiz/types'
-import type { Link, Script } from '@unhead/schema'
+import type { UseHeadInput } from 'unhead/types'
 
 export function useRoadizHead(webResponse?: RoadizWebResponse, alternateLinks?: RoadizAlternateLink[]) {
     const nuxtApp = useNuxtApp()
     const route = useRoute()
     const runtimeConfig = useRuntimeConfig()
     const { $i18n } = nuxtApp
-    const script: (Script<['script']> | string)[] = []
-    const link: Link[] = [
+    const script: UseHeadInput['script'] = []
+    const link: UseHeadInput['link'] = [
         {
             rel: 'canonical',
             href: joinURL(runtimeConfig.public.site.url, webResponse?.item?.url || route.path),
@@ -16,14 +16,16 @@ export function useRoadizHead(webResponse?: RoadizWebResponse, alternateLinks?: 
     ]
 
     // ALTERNATE LINKS
-    const alternateLinksHead = alternateLinks?.map((alternateLink: RoadizAlternateLink) => {
-        return {
-            hid: `alternate-${alternateLink.locale}`,
-            rel: 'alternate',
-            hreflang: alternateLink.locale,
-            href: joinURL(runtimeConfig.public.site.url, alternateLink.url),
-        }
-    })
+    const alternateLinksHead = alternateLinks
+        ?.filter(alternateLink => alternateLink.url)
+        .map((alternateLink: RoadizAlternateLink) => {
+            return {
+                hid: `alternate-${alternateLink.locale}`,
+                rel: 'alternate',
+                hreflang: alternateLink.locale,
+                href: joinURL(runtimeConfig.public.site.url, alternateLink.url!),
+            }
+        })
     if (alternateLinksHead) link.push(...alternateLinksHead)
 
     useHead({

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -1,0 +1,5 @@
+import type { RoadizWebResponse } from '@roadiz/types'
+
+export type PageEntityProps = {
+    webResponse?: RoadizWebResponse
+}

--- a/types/roadiz.d.ts
+++ b/types/roadiz.d.ts
@@ -20,3 +20,5 @@ export interface NSMenuLink extends RoadizNodesSources {
     linkExternalUrl?: string
     linkInternalReference?: Array<RoadizNodesSources>
 }
+
+export type NSPage = RoadizNodesSources


### PR DESCRIPTION
- use shallow ref for current and next page data
- keep reactivity for web response
- improve default page component
- fix alternate links typing
- add common cache composable
- do not use `callOnce()` in the layout for more straightforward data management