### PR TITLE
ci(husky): Use Dockerized linting command in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/common.sh"
 
 # Echo a message when yarn lint command fails
-pnpm lint || (echo "$(tput setaf 1)\nLinting failed. Please fix the errors using \"pnpm lint-fix\" and try again.\n$(tput sgr0)" && exit 1)
+docker compose run --rm node pnpm lint || (echo "$(tput setaf 1)\nLinting failed. Please fix the errors using \"pnpm lint-fix\" and try again.\n$(tput sgr0)" && exit 1)


### PR DESCRIPTION
Use docker for run prepush lint, it's useful for backend users who doesn't have node.