### PR TITLE
chore: Disallow all /api routes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -265,7 +265,7 @@ export default defineNuxtConfig({
     // https://nuxtseo.com/robots/api/config
     robots: {
         allow: ['/'],
-        disallow: ['/rz-admin', '/maintenance', '/_icons', '/api/docs', '/api/.well-known/genid/'],
+        disallow: ['/rz-admin', '/maintenance', '/_icons', '/api'],
     },
     // https://www.nuxtseo.com/sitemap/getting-started/installation
     sitemap: {


### PR DESCRIPTION
You were right @timothejoubert, no need for /api at all, it's flodding Google Bot with 404 URLs