### PR TITLE
feat: handle file URL as special case

### DIFF
--- a/app/components/VRoadizLink.vue
+++ b/app/components/VRoadizLink.vue
@@ -29,11 +29,22 @@ export default defineComponent({
         const attributes = computed<Record<string, unknown>>(() => {
             const defaultAttrs = { ...attrs, ...props.nuxtLinkProps }
 
-            // Download
+            // Document
             if (props.document?.relativePath) {
                 return {
                     ...defaultAttrs,
                     href: useRoadizDocumentUrl(props.document?.relativePath),
+                    target: attrs?.target || '_blank',
+                    rel: attrs?.rel || 'noopener noreferrer',
+                    download: '',
+                }
+            }
+
+            // File link
+            if (props.url && isFileUrl(props.url)) {
+                return {
+                    ...defaultAttrs,
+                    href: props.url,
                     target: attrs?.target || '_blank',
                     rel: attrs?.rel || 'noopener noreferrer',
                     download: '',
@@ -47,6 +58,7 @@ export default defineComponent({
                     href: props.url,
                     target: attrs?.target || '_blank',
                     rel: attrs?.rel || 'noopener noreferrer',
+                    external: true, // Ensure NuxtLink handles it as external link
                 }
             }
 
@@ -71,6 +83,7 @@ export default defineComponent({
                 return {
                     ...defaultAttrs,
                     to: props.url,
+                    external: true, // Ensure NuxtLink handles it as external link
                 }
             }
 

--- a/app/components/VRoadizLink.vue
+++ b/app/components/VRoadizLink.vue
@@ -36,7 +36,6 @@ export default defineComponent({
                     href: useRoadizDocumentUrl(props.document?.relativePath),
                     target: attrs?.target || '_blank',
                     rel: attrs?.rel || 'noopener noreferrer',
-                    download: '',
                 }
             }
 
@@ -47,13 +46,6 @@ export default defineComponent({
                     href: props.url,
                     target: attrs?.target || '_blank',
                     rel: attrs?.rel || 'noopener noreferrer',
-                    // If the file URL contains executable extensions (html, php, etc.)
-                    // we could expect another domain (because this is not our way of doing things)
-                    // so the download attribute will be ignored by the browser
-                    // and the file will be opened in a new tab instead of being downloaded.
-                    // In this case, the external link handling will take precedence
-                    // and the link will be treated as an external link.
-                    download: '',
                 }
             }
 

--- a/app/components/VRoadizLink.vue
+++ b/app/components/VRoadizLink.vue
@@ -47,6 +47,12 @@ export default defineComponent({
                     href: props.url,
                     target: attrs?.target || '_blank',
                     rel: attrs?.rel || 'noopener noreferrer',
+                    // If the file URL contains executable extensions (html, php, etc.)
+                    // we could expect another domain (because this is not our way of doing things)
+                    // so the download attribute will be ignored by the browser
+                    // and the file will be opened in a new tab instead of being downloaded.
+                    // In this case, the external link handling will take precedence
+                    // and the link will be treated as an external link.
                     download: '',
                 }
             }

--- a/app/utils/url.ts
+++ b/app/utils/url.ts
@@ -19,3 +19,9 @@ export function isInternalURL(url: string, siteUrl?: string) {
 export function isExternalUrl(url: string, siteUrl?: string) {
     return isHttpUrlScheme(url) && !isInternalURL(url, siteUrl)
 }
+
+// Strips query string and hash, then checks the last path segment ends with a dot-extension.
+// [^./]+ excludes dots and slashes so a dot in a directory name (e.g. /v1.2/release) doesn't match.
+export function isFileUrl(url: string) {
+    return /\.[^./]+$/.test(url.replace(/[?#].*$/, ''))
+}


### PR DESCRIPTION
- Inside the `RoadizLink` component, if the URL contains a file extension then we handle it as external.
- Add `external` to external link for ensuring `NuxtLink` treat them like external link