### PR TITLE
refactor: declare runtime props to prevent attribute fallthrough

### DIFF
--- a/app/components/VRoadizBlockFactory.ts
+++ b/app/components/VRoadizBlockFactory.ts
@@ -1,12 +1,16 @@
-import type { FunctionalComponent, VNodeChild } from 'vue'
+import type { ExtractPropTypes, FunctionalComponent, VNodeChild } from 'vue'
 import { h, resolveDynamicComponent, resolveComponent } from 'vue'
 import type { RoadizWalker } from '@roadiz/types'
 
-export interface RoadizBlockFactoryProps {
-    prefix?: string
-    blocks: RoadizWalker[]
-    [key: string]: unknown
+const props = {
+    prefix: String,
+    blocks: {
+        type: Array as () => RoadizWalker[],
+        required: true as const,
+    },
 }
+
+export type RoadizBlockFactoryProps = ExtractPropTypes<typeof props>
 
 const isComponent = (component: string | undefined): boolean => {
     return typeof resolveDynamicComponent(component) !== 'string'
@@ -35,5 +39,7 @@ const RoadizBlockFactory: FunctionalComponent<RoadizBlockFactoryProps> = ({ bloc
         }
     })
 }
+
+RoadizBlockFactory.props = props
 
 export default RoadizBlockFactory


### PR DESCRIPTION
Previously, VRoadizBlockFactory only had a TypeScript interface for its props. Without a runtime props declaration, Vue's runtime had no way to distinguish props from fallthrough attributes — meaning blocks and prefix were included in $attrs and could end up as HTML attributes on child elements via ...context.attrs.