### PR TITLE
fix(VRoadizMedia): return null instead of empty vnode when tag is not defined

### DIFF
--- a/app/components/VRoadizMedia.vue
+++ b/app/components/VRoadizMedia.vue
@@ -49,7 +49,7 @@ export default defineComponent({
             return undefined
         })
 
-        if (!tag.value) return () => h('')
+        if (!tag.value) return () => null
 
         const nodeProps = computed(() => {
             const result = { document: displayedDocument.value }


### PR DESCRIPTION
To avoid this error when the `mediaType.value` is undefined:

```
installHook.js:1 [Vue warn]: Invalid vnode type when creating vnode: . 
  at <VRoadizMedia document= 
Object
...
```