### PR TITLE
fix: update component name formatting in dev mode to replace dots with dashes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -169,7 +169,7 @@ export default defineNuxtConfig({
                     const hash = createHash('md5').update(cleanFilename).digest('hex').substring(0, 5)
                     // in dev mode, display the componentName in the className
                     if (isDev) {
-                        const componentName = cleanFilename.split('/').pop()?.replace(/\.vue.*$/, '') ?? ''
+                        const componentName = cleanFilename.split('/').pop()?.replace(/\.vue.*$/, '').replace(/\./g, '-') ?? ''
                         return `${componentName}_${name}_${hash}`
                     }
                     return `_${name}_${hash}`


### PR DESCRIPTION
Replace dots in the component name with hyphens before building the scoped name. Hyphens are valid in CSS identifiers and produce a correct single-class selector: `.Variants.stories_row_35b15.` VS `.Variants-stories_row_35b15.`