### PR TITLE
build: remove pnpm shamefully hoist

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-shamefully-hoist=true
 strict-peer-dependencies=false


### PR DESCRIPTION
This is no longer required for deps