### PR TITLE
refactor(use-roadiz-menu): rely on computed url from roadiz skeleton

### DIFF
--- a/app/composables/use-roadiz-menu.ts
+++ b/app/composables/use-roadiz-menu.ts
@@ -12,8 +12,7 @@ export interface MenuItem {
 function parseWalker(walker: RoadizWalker): MenuItem {
     return {
         title: walker.item?.title,
-        // @ts-expect-error linkExternalUrl is not in the type definition
-        url: walker.item?.linkExternalUrl as string | undefined ?? walker.item?.url,
+        url: walker.item?.url,
         // @ts-expect-error linkInternalReference is not in the type definition
         reference: walker.item?.linkInternalReference as RoadizNodesSources[] | undefined,
         slug: walker.item?.slug,


### PR DESCRIPTION
The Roadiz skeleton now exposes a server-side computed `url` field via MenuLinkPathNormalizer (linkExternalUrl or internal URL). We can therefore drop the linkExternalUrl fallback and consume item.url directly, which also removes a @ts-expect-error.

Ref: https://github.com/roadiz/skeleton/blob/develop/src/Serializer/Normalizer/MenuLinkPathNormalizer.php